### PR TITLE
Hi! BigCrystal cannot upload characters

### DIFF
--- a/src/BigCrystal.cpp
+++ b/src/BigCrystal.cpp
@@ -7,9 +7,10 @@ BigCrystal::BigCrystal(LCD *display) {
 BigCrystal::BigCrystal(LiquidCrystal *display) {
 #endif
   _display = display;
+  #ifndef LiquidCrystal_h 
   createCustomChars();
+  #endif
 }
-
 
 /* Creates custom font shapes for LCD characters 0 through to 7
  * used in displaying big fonts

--- a/src/BigCrystal.cpp
+++ b/src/BigCrystal.cpp
@@ -7,7 +7,7 @@ BigCrystal::BigCrystal(LCD *display) {
 BigCrystal::BigCrystal(LiquidCrystal *display) {
 #endif
   _display = display;
-  #ifndef LiquidCrystal_h 
+  #ifdef LiquidCrystal_h 
   createCustomChars();
   #endif
 }

--- a/src/BigCrystal.h
+++ b/src/BigCrystal.h
@@ -76,6 +76,9 @@ public:
   /* Delegate methods to underlying LCD instance */
   inline void begin(uint8_t cols, uint8_t rows, uint8_t charsize = LCD_5x8DOTS) {
     _display->begin(cols, rows, charsize);
+    #ifndef LiquidCrystal_h 
+    createCustomChars();
+    #endif
   }
   inline void clear() { _display->clear(); }
   inline void home() { _display->home(); }


### PR DESCRIPTION
BigCrystal cannot upload characters from its constructor via I2C. 
I dont know why. May be because it is before a global Wire.begin or something else.
I have moved createCharacters() to begin() method where it works.

Please let me know your decision.

Yours Sergio