### PR TITLE
bugfixes

### DIFF
--- a/src/BigCrystal.cpp
+++ b/src/BigCrystal.cpp
@@ -84,7 +84,7 @@ uint8_t BigCrystal::printBig(char *str, uint8_t col, uint8_t row) {
   char *c = str;
   while (*c != '\0') {
     width += writeBig(*c, col + width, row);
-    *c++;
+    c++;
   }
   return width;
 }

--- a/src/BigCrystal.h
+++ b/src/BigCrystal.h
@@ -96,7 +96,7 @@ public:
   inline void noAutoscroll() { _display->noAutoscroll(); }
   inline void createChar(uint8_t location, uint8_t charmap[]) { _display->createChar(location, charmap); }
   inline void setCursor(uint8_t col, uint8_t row) { _display->setCursor(col, row); }
-  inline virtual size_t write(uint8_t value) { _display->write(value); }
+  inline virtual size_t write(uint8_t value) { return _display->write(value); }
 
   using Print::write;
 private:


### PR DESCRIPTION
Hi,

found two possible reasons for the memory corruptions I experienced while using BigCrystal.

have not tested the changes yet.

cheers,
Bernhard